### PR TITLE
Powerpc : omit -Os flag to avoid use of _savegrp_* and add

### DIFF
--- a/src/stub/Makefile
+++ b/src/stub/Makefile
@@ -1247,7 +1247,7 @@ powerpc-linux.elf%.h : tc_list = powerpc-linux.elf default
 powerpc-linux.elf%.h : tc_bfdname = elf32-powerpc
 
 tc.powerpc-linux.elf.gcc  = powerpc.405-linux-gcc-3.4.5 -m32 -mbig-endian -mtune=powerpc -nostdinc -MMD -MT $@
-tc.powerpc-linux.elf.gcc += -fno-exceptions -fno-asynchronous-unwind-tables -fno-stack-protector
+tc.powerpc-linux.elf.gcc += -fno-exceptions -fno-asynchronous-unwind-tables # -fno-stack-protector
 tc.powerpc-linux.elf.gcc += -Wall -W -Wcast-align -Wcast-qual -Wstrict-prototypes -Wwrite-strings -Werror
 
 powerpc-linux.elf-entry.h : $(srcdir)/src/$$T.S

--- a/src/stub/Makefile
+++ b/src/stub/Makefile
@@ -1221,7 +1221,7 @@ tmp/powerpc-darwin.macho-fold.o : $(srcdir)/src/$$T.S
 	$(call tc,f-objstrip,$@)
 
 tmp/powerpc-darwin.macho-main.o : $(srcdir)/src/$$T.c
-	$(call tc,gcc) -c -Os $< -o $@
+	$(call tc,gcc) -c $< -o $@
 	$(call tc,f-objstrip,$@)
 
 
@@ -1247,7 +1247,7 @@ powerpc-linux.elf%.h : tc_list = powerpc-linux.elf default
 powerpc-linux.elf%.h : tc_bfdname = elf32-powerpc
 
 tc.powerpc-linux.elf.gcc  = powerpc.405-linux-gcc-3.4.5 -m32 -mbig-endian -mtune=powerpc -nostdinc -MMD -MT $@
-tc.powerpc-linux.elf.gcc += -fno-exceptions -fno-asynchronous-unwind-tables   # -fno-stack-protector
+tc.powerpc-linux.elf.gcc += -fno-exceptions -fno-asynchronous-unwind-tables -fno-stack-protector
 tc.powerpc-linux.elf.gcc += -Wall -W -Wcast-align -Wcast-qual -Wstrict-prototypes -Wwrite-strings -Werror
 
 powerpc-linux.elf-entry.h : $(srcdir)/src/$$T.S
@@ -1266,7 +1266,7 @@ tmp/powerpc-linux.elf-fold.o : $(srcdir)/src/$$T.S
 	$(call tc,f-objstrip,$@)
 
 tmp/powerpc-linux.elf-main.o : $(srcdir)/src/$$T.c
-	$(call tc,gcc) -c -Os $< -o $@
+	$(call tc,gcc) -c $< -o $@
 	$(call tc,f-objstrip,$@)
 
 


### PR DESCRIPTION
Omit -Os flag to avoid use of _savegrp_\* and add -fno-stack-protector flag.

Signed-off-by: Thierry Fauck tfauck@free.fr

```
modified:   stub/Makefile
```
