### PR TITLE
Explicitely specify cmp instructions to be 32 bits or 64bits …

### DIFF
--- a/src/stub/src/arch/powerpc/32/bxx.S
+++ b/src/stub/src/arch/powerpc/32/bxx.S
@@ -36,10 +36,10 @@ ppcbxx:  # (*f_unf)(xo->buf, out_len, h.b_cto8, h.b_ftid);
 
 #define ptr0 a4
 
-        cmpli cr0,ftid,0xd0;       bnelr- cr0  # if (0xd0!=ftid)   return;
+        cmpli cr0,0,ftid,0xd0;       bnelr- cr0  # if (0xd0!=ftid)   return;
         rlwinm. len,len,32-2,2,31; beqlr- cr0  # if (0==(len>>=2)) return;
         lis r0,-(~0<<(32-16- (2+6+ W_CTO)))  # limit in 32-bit words
-        cmpl cr0,len,r0
+        cmpl cr0,0,len,r0
         blt  cr0,L5
         mr       len,r0
 L5:
@@ -58,7 +58,7 @@ L10:
 L20:
         lwzu t0,4(ptr)  # t0= *++ptr;
         rlwinm t1,t0,6+W_CTO,32-(6+W_CTO),31  # t1= top (6+W_CTO) bits of t0
-        cmpl cr0,t1,cto8; beq- cr0,L10  # unconditional branch marked with cto8; unlikely
+        cmpl cr0,0,t1,cto8; beq- cr0,L10  # unconditional branch marked with cto8; unlikely
         bdnz+ L20  # if (0!=--ctr) goto L20;  // likely
         ret
 

--- a/src/stub/src/arch/powerpc/64le/bxx.S
+++ b/src/stub/src/arch/powerpc/64le/bxx.S
@@ -36,10 +36,10 @@ ppcbxx:  # (*f_unf)(xo->buf, out_len, h.b_cto8, h.b_ftid);
 
 #define ptr0 a4
 
-        cmpli cr0,ftid,0xd0;       bnelr- cr0  # if (0xd0!=ftid)   return;
+        cmpli cr0,0,ftid,0xd0;       bnelr- cr0  # if (0xd0!=ftid)   return;
         rlwinm. len,len,32-2,2,31; beqlr- cr0  # if (0==(len>>=2)) return;
         lis r0,-(~0<<(32-16- (2+6+ W_CTO)))  # limit in 32-bit words
-        cmpl cr0,len,r0
+        cmpl cr0,0,len,r0
         blt  cr0,L5
         mr       len,r0
 L5:
@@ -58,7 +58,7 @@ L10:
 L20:
         lwzu t0,4(ptr)  # t0= *++ptr;
         rlwinm t1,t0,6+W_CTO,32-(6+W_CTO),31  # t1= top (6+W_CTO) bits of t0
-        cmpl cr0,t1,cto8; beq- cr0,L10  # unconditional branch marked with cto8; unlikely
+        cmpl cr0,0,t1,cto8; beq- cr0,L10  # unconditional branch marked with cto8; unlikely
         bdnz+ L20  # if (0!=--ctr) goto L20;  // likely
         ret
 

--- a/src/stub/src/arch/powerpc/64le/lzma_d.S
+++ b/src/stub/src/arch/powerpc/64le/lzma_d.S
@@ -44,7 +44,7 @@ retaddr = 6*8  // (sp,cr,pc, xx,yy,zz) save area per calling convention
 ////  teq r0,r0  // debugging
 
 #define M_LZMA          14
-        cmpli cr0,meth,M_LZMA
+        cmpli cr0,0,meth,M_LZMA
         bne   cr0,not_lzma
         mflr r0
 
@@ -82,7 +82,7 @@ retaddr = 6*8  // (sp,cr,pc, xx,yy,zz) save area per calling convention
         stw r0,0(a6)  // outSizeProcessed= 0;
 1:
         stwu r0,-4(a0)  // clear CLZmaDecoderState on stack
-        cmpl cr0,sp,a0  // compare logical ==> compare unsigned
+        cmpl cr0,0,sp,a0  // compare logical ==> compare unsigned
         blt cr0,1b
         stw a3,0(sp)  // frame chain
 

--- a/src/stub/src/arch/powerpc/64le/nrv2b_d.S
+++ b/src/stub/src/arch/powerpc/64le/nrv2b_d.S
@@ -33,7 +33,7 @@
         dcbtst 0,dst  // prime dcache for store
         mflr t3  // return address
 
-        cmpli cr0,meth,M_NRV2B_LE32
+        cmpli cr0,0,meth,M_NRV2B_LE32
         bne   cr0,not_nrv2b
 
         std dst,0(ldst)  // original dst

--- a/src/stub/src/arch/powerpc/64le/nrv2d_d.S
+++ b/src/stub/src/arch/powerpc/64le/nrv2d_d.S
@@ -33,7 +33,7 @@
         dcbtst 0,dst  // prime dcache for store
         mflr t3  // return address
 
-        cmpli cr0,meth,M_NRV2D_LE32
+        cmpli cr0,0,meth,M_NRV2D_LE32
         bne   cr0,not_nrv2d
 
         std dst,0(ldst)  // original dst

--- a/src/stub/src/arch/powerpc/64le/nrv2e_d.S
+++ b/src/stub/src/arch/powerpc/64le/nrv2e_d.S
@@ -33,7 +33,7 @@
         dcbtst 0,dst  // prime dcache for store
         mflr t3  // return address
 
-        cmpli cr0,meth,M_NRV2E_LE32
+        cmpli cr0,0,meth,M_NRV2E_LE32
         bne   cr0,not_nrv2e
 
         std dst,0(ldst)  // original dst

--- a/src/stub/src/powerpc64le-darwin.dylib-entry.S
+++ b/src/stub/src/powerpc64le-darwin.dylib-entry.S
@@ -101,7 +101,7 @@ CACHELINE=32
         ori dst0,dst0,-1+ CACHELINE  // highest addr on cache line
 cfl_nrv:
         dcbst  0,dst0  // initiate store (modified) cacheline to memory
-        cmpl cr0,dst0,dst  // did we cover the highest-addressed byte?
+        cmpl cr0,0,dst0,dst  // did we cover the highest-addressed byte?
         icbi   0,dst0  // discard instructions from cacheline
         addi     dst0,dst0,CACHELINE  // highest addr on next line
         blt  cr0,cfl_nrv  // not done yet
@@ -265,7 +265,7 @@ dy_uncpr:
                 // FIXME: check status
 
         lbz a3,b_ftid(s_cpr)
-        cmpli cr0,a3,0
+        cmpli cr0,0,a3,0
         beq dy_uncpr
         lbz a2,b_cto8(s_cpr)
         ld a1,sz_unc(s_cpr)

--- a/src/stub/src/powerpc64le-darwin.macho-entry.S
+++ b/src/stub/src/powerpc64le-darwin.macho-entry.S
@@ -87,7 +87,7 @@ CACHELINE=32
         ori dst0,dst0,-1+ CACHELINE  // highest addr on cache line
 cfl_nrv:
         dcbst  0,dst0  // initiate store (modified) cacheline to memory
-        cmpl cr0,dst0,dst  // did we cover the highest-addressed byte?
+        cmpl cr0,0,dst0,dst  // did we cover the highest-addressed byte?
         icbi   0,dst0  // discard instructions from cacheline
         addi     dst0,dst0,CACHELINE  // highest addr on next line
         blt  cr0,cfl_nrv  // not done yet

--- a/src/stub/src/powerpc64le-darwin.macho-fold.S
+++ b/src/stub/src/powerpc64le-darwin.macho-fold.S
@@ -71,7 +71,7 @@ L90:
         lwz a1,-8(r31)  # offset to {l_info; p_info; b_info}
         subf a0,a1,r31  # &l_info
         lwz a3,sz_unc+sz_p_info+sz_l_info(a0)  # sz_mach_headers
-        cmpli 0,a3,2048; bgt L100; li a3,2048  # at least 2 KiB for /usr/lib/dyld
+        cmpli 0,0,a3,2048; bgt L100; li a3,2048  # at least 2 KiB for /usr/lib/dyld
 L100:
         movr r29,sp  # remember for restoring later
         subf sp,a3,sp  # alloca

--- a/src/stub/src/powerpc64le-linux.elf-entry.S
+++ b/src/stub/src/powerpc64le-linux.elf-entry.S
@@ -114,7 +114,7 @@ CACHELINE=32
         ori dst0,dst0,-1+ CACHELINE  // highest addr on cache line
 cfl_nrv:
         dcbst  0,dst0  // initiate store (modified) cacheline to memory
-        cmpl cr0,dst0,dst  // did we cover the highest-addressed byte?
+        cmpl cr0,0,dst0,dst  // did we cover the highest-addressed byte?
         icbi   0,dst0  // discard instructions from cacheline
         addi     dst0,dst0,CACHELINE  // highest addr on next line
         blt  cr0,cfl_nrv  // not done yet

--- a/src/stub/src/powerpc64le-linux.elf-fold.S
+++ b/src/stub/src/powerpc64le-linux.elf-fold.S
@@ -65,7 +65,7 @@ fold_begin:
 zfind:
         ld t0,0(a6)        // parameters are 16byte aligned
         addi a6,a6,8
-        cmpi cr7,t0,0; bne+ cr7,zfind
+        cmpi cr7,0,t0,0; bne+ cr7,zfind
         ret
 L90:
         la sp,LINKAREA(sp)  // trim save area used by decompressor

--- a/src/stub/src/powerpc64le-linux.kernel.vmlinux.S
+++ b/src/stub/src/powerpc64le-linux.kernel.vmlinux.S
@@ -116,7 +116,7 @@ CACHELINE=32
         ori dst0,dst0,-1+ CACHELINE  // highest addr on cache line
 cfl_nrv:
         dcbst  0,dst0  // initiate store (modified) cacheline to memory
-        cmpl cr0,dst0,dst  // did we cover the highest-addressed byte?
+        cmpl cr0,0,dst0,dst  // did we cover the highest-addressed byte?
         icbi   0,dst0  // discard instructions from cacheline
         addi     dst0,dst0,CACHELINE  // highest addr on next line
         blt  cr0,cfl_nrv  // not done yet


### PR DESCRIPTION
…on powerpc

Signed-off-by: Thierry Fauck <tfauck@free.fr>

	modified:   stub/src/arch/powerpc/32/bxx.S
	modified:   stub/src/arch/powerpc/64le/bxx.S
	modified:   stub/src/arch/powerpc/64le/lzma_d.S
	modified:   stub/src/arch/powerpc/64le/nrv2b_d.S
	modified:   stub/src/arch/powerpc/64le/nrv2d_d.S
	modified:   stub/src/arch/powerpc/64le/nrv2e_d.S
	modified:   stub/src/powerpc64le-darwin.dylib-entry.S
	modified:   stub/src/powerpc64le-darwin.macho-entry.S
	modified:   stub/src/powerpc64le-darwin.macho-fold.S
	modified:   stub/src/powerpc64le-linux.elf-entry.S
	modified:   stub/src/powerpc64le-linux.elf-fold.S
	modified:   stub/src/powerpc64le-linux.kernel.vmlinux.S