### PR TITLE
PE: fix RVA/offset mixup and comparison against a constant

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1111,9 +1111,9 @@ void PeFile::Export::convert(unsigned eoffs,unsigned esize)
     size = sizeof(export_dir_t);
     iv.add(eoffs,size);
 
-    if (getsize() <= (unsigned)edir.name) {
+    if (eoffs + esize <= (unsigned)edir.name) {
         char msg[50]; snprintf(msg, sizeof(msg),
-                "bad export directory name offset %#x", (unsigned)edir.name);
+                "bad export directory name RVA %#x", (unsigned)edir.name);
         throwInternalError(msg);
     }
     unsigned len = strlen(base + edir.name) + 1;


### PR DESCRIPTION
Since pulling the latest `devel` branch I can no longer compress DLL files (or any PE with an export directory for that matter). This is due to a minor mistake in 563165e: the LHS in this check will always be `sizeof(export_dir_t) == 0x28` because `size` is assigned this value 2 lines earlier in the same function. I changed the check to what I believe was intended: the VA of the `Name` field should not exceed the combined VA and size of the export directory.

Note that this is actually still (much) stricter than the Windows loader behaviour (which as far as I can tell isn't even aware the `Name` field exists), but that's not a bad thing IMO. UPX already rejects plenty of things that are technically valid in a PE and that ntdll will even load but which no sane linker would output.