### PR TITLE
heap overflow in packhead.cpp (base: devel)

### DIFF
--- a/src/packhead.cpp
+++ b/src/packhead.cpp
@@ -85,6 +85,29 @@ int PackHeader::getPackHeaderSize() const {
     return n;
 }
 
+static bool packheader_size_valid(int format, int boff, int blen)
+{
+    int p_size = 0;
+    if(format < 128) {
+        if(format == UPX_F_DOS_COM || format == UPX_F_DOS_SYS) {
+            p_size = 21;
+        }
+        else if (format == UPX_F_DOS_EXE || format == UPX_F_DOS_EXEH) {
+			p_size = 26;
+		}
+		else {
+			p_size = 31;
+		}
+    }
+    else {
+        p_size = 31;
+    }
+
+    if( boff + p_size > blen )
+        return false;
+    return true;
+}
+
 /*************************************************************************
 // see stub/header.ash
 **************************************************************************/
@@ -186,7 +209,7 @@ bool PackHeader::fillPackHeader(const upx_bytep buf, int blen) {
                 format, method, level);
     }
     const int size = getPackHeaderSize();
-    if (boff + size <= 0 || boff + size > blen)
+    if (boff + size <= 0 || boff + size > blen || !packheader_size_valid(format, boff, blen))
         throwCantUnpack("header corrupted 2");
 
     //


### PR DESCRIPTION
A heap buffer overflow occurs during decompression.

When unpacking the PoC file [heap_overflow.zip](https://github.com/upx/upx/files/3111506/heap_overflow.zip), you can check the following logs.
The PoC file is an abnormal UPX file.

```
 ./upx.out -d ../../sample/pack_err
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2018
UPX 3.95        Markus Oberhumer, Laszlo Molnar & John Reiser   Aug 26th 2018

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
=================================================================
==5709==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62500000e949 at pc 0x530f69 bp 0x7ffed04f19a0 sp 0x7ffed04f1998
READ of size 1 at 0x62500000e949 thread T0
    #0 0x530f68 in acc_ua_get_le32(void const*) /home/<username>/upx/src/miniacc.h:6104
    #1 0x4fa640 in get_le32 /home/<username>/upx/src/bele.h:166
    #2 0x4fa640 in PackHeader::fillPackHeader(unsigned char const*, int) /home/<username>/upx/src/packhead.cpp:213
    #3 0x4efc8c in Packer::getPackHeader(void*, int, bool) /home/<username>/upx/src/packer.cpp:716
    #4 0x4bc48a in PackUnix::canUnpack() /home/<username>/upx/src/p_unix.cpp:538
    #5 0x4fb0e7 in try_unpack /home/<username>/upx/src/packmast.cpp:114
    #6 0x4fc0b3 in PackMaster::visitAllPackers(Packer* (*)(Packer*, void*), InputFile*, options_t const*, void*) /home/<username>/upx/src/packmast.cpp:190
    #7 0x4ff351 in PackMaster::getUnpacker(InputFile*) /home/<username>/upx/src/packmast.cpp:248
    #8 0x4ff495 in PackMaster::unpack(OutputFile*) /home/<username>/upx/src/packmast.cpp:266
    #9 0x537c22 in do_one_file(char const*, char*) /home/<username>/upx/src/work.cpp:160
    #10 0x538129 in do_files(int, int, char**) /home/<username>/upx/src/work.cpp:271
    #11 0x4040a9 in main /home/<username>/upx/src/main.cpp:1539
    #12 0x7f1f9182bf44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)
    #13 0x404e11 (/home/<username>/upx/src/upx.out+0x404e11)

0x62500000e949 is located 0 bytes to the right of 8265-byte region [0x62500000c900,0x62500000e949)
allocated by thread T0 here:
    #0 0x7f1f9236e862 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x54862)
    #1 0x4315f4 in MemBuffer::alloc(unsigned long long) /home/<username>/upx/src/mem.cpp:194
    #2 0x4bc32a in PackUnix::canUnpack() /home/<username>/upx/src/p_unix.cpp:530
    #3 0x4fb0e7 in try_unpack /home/<username>/upx/src/packmast.cpp:114
    #4 0x4fc0b3 in PackMaster::visitAllPackers(Packer* (*)(Packer*, void*), InputFile*, options_t const*, void*) /home/<username>/upx/src/packmast.cpp:190
    #5 0x4ff351 in PackMaster::getUnpacker(InputFile*) /home/<username>/upx/src/packmast.cpp:248
    #6 0x4ff495 in PackMaster::unpack(OutputFile*) /home/<username>/upx/src/packmast.cpp:266
    #7 0x537c22 in do_one_file(char const*, char*) /home/<username>/upx/src/work.cpp:160
    #8 0x538129 in do_files(int, int, char**) /home/<username>/upx/src/work.cpp:271
    #9 0x4040a9 in main /home/<username>/upx/src/main.cpp:1539
    #10 0x7f1f9182bf44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/<username>/upx/src/miniacc.h:6104 acc_ua_get_le32(void const*)
Shadow bytes around the buggy address:
  0x0c4a7fff9cd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a7fff9ce0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a7fff9cf0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a7fff9d00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4a7fff9d10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c4a7fff9d20: 00 00 00 00 00 00 00 00 00[01]fa fa fa fa fa fa
  0x0c4a7fff9d30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a7fff9d40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a7fff9d50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a7fff9d60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a7fff9d70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Contiguous container OOB:fc
  ASan internal:           fe
==5709==ABORTING`
```
The code that gets pack header information reads the header values ​​regardless of version.
So, before getting the pack header information according to the format, I add a function that checks the buffer size actually needed.