### PR TITLE
Fix: Allow overlap of MZ header and PE header

### DIFF
--- a/src/p_armpe.cpp
+++ b/src/p_armpe.cpp
@@ -237,7 +237,8 @@ void PackArmPe::defineSymbols(unsigned ncsection, unsigned, unsigned,
 
 void PackArmPe::setOhDataBase(const pe_section_t *osection)
 {
-    oh.database = osection[2].vaddr;
+    if (oh.database > oh.headersize) // NOT overlaped MZ and PE headers
+        oh.database = osection[2].vaddr;
 }
 
 void PackArmPe::setOhHeaderSize(const pe_section_t *osection)

--- a/src/p_w32pe.cpp
+++ b/src/p_w32pe.cpp
@@ -273,7 +273,8 @@ void PackW32Pe::addNewRelocations(Reloc &rel, unsigned base)
 
 void PackW32Pe::setOhDataBase(const pe_section_t *osection)
 {
-    oh.database = osection[2].vaddr;
+    if (oh.database > oh.headersize) // NOT overlaped MZ and PE headers
+        oh.database = osection[2].vaddr;
 }
 
 void PackW32Pe::setOhHeaderSize(const pe_section_t *)

--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -164,7 +164,7 @@ int PeFile::readFileHeader()
         {
             unsigned const delta = (h.relocoffs >= 0x40)
                 ? h.nexepos // new format exe
-                : (h.p512*512+h.m512 - h.m512 ? 512 : h.nexepos);
+                : (h.p512*512 + (h.m512 ? h.m512-512 : h.p512 ? 0 : h.nexepos));
 
             if ((pe_offset + delta) < delta  // wrap-around
             ||  (pe_offset + delta) > (unsigned)file_size) {


### PR DESCRIPTION
commit/f056ecdcd50dbf881194ba6998e5e1d2e8cc10f3