### PR TITLE
PE: fix load configuration directory alignment

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -2427,7 +2427,7 @@ void PeFile::pack0(OutputFile *fo, ht &ih, ht &oh,
     processTls(&rel,&tlsiv,ic);
     ODADDR(PEDIR_TLS) = sotls ? ic : 0;
     ODSIZE(PEDIR_TLS) = sotls ? (sizeof(LEXX) == 4 ? 0x18 : 0x28) : 0;
-    ic += sotls;
+    ic = ALIGN_UP(ic + sotls, 4u);
 
     processLoadConf(&rel, &loadconfiv, ic);
     ODADDR(PEDIR_LOADCONF) = soloadconf ? ic : 0;


### PR DESCRIPTION
This fixes #182, #228, #294, and one of the [issues listed in #154](https://github.com/upx/upx/issues/154#issuecomment-368741687).

Note 1: in some of the above issues I stated that the load config directory must be quadword aligned for PE64 files. This is incorrect; I later found that this restriction can be reduced to dword alignment.

Note 2: the above issues are tagged as/commented on to imply they are Windows 10 related, but this is not the case, except for #154 which is more of a meta-issue I guess. The problem (executable refuses to start) can actually be reproduced on XP, and probably even older versions than that.