### PR TITLE
Don't pack Cotrol Flow Guard PE files

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -2107,7 +2107,8 @@ void PeFile::readSectionHeaders(unsigned objs, unsigned sizeof_ih)
 }
 
 void PeFile::checkHeaderValues(unsigned subsystem, unsigned mask,
-                               unsigned ih_entry, unsigned ih_filealign)
+                               unsigned ih_entry, unsigned ih_filealign,
+                               unsigned ih_dllflags)
 {
     if ((1u << subsystem) & ~mask)
     {
@@ -2131,6 +2132,9 @@ void PeFile::checkHeaderValues(unsigned subsystem, unsigned mask,
 
     if (ih_filealign < 0x200)
         throwCantPack("filealign < 0x200 is not yet supported");
+
+    if (ih_dllflags & IMAGE_DLLCHARACTERISTICS_CONTROL_FLOW_GUARD)
+        throwCantPack("CFGuard enabled PE files are not supported");
 }
 
 unsigned PeFile::handleStripRelocs(upx_uint64_t ih_imagebase,
@@ -2240,7 +2244,7 @@ void PeFile::pack0(OutputFile *fo, ht &ih, ht &oh,
     readSectionHeaders(objs, sizeof(ih));
     if (!opt->force && handleForceOption())
         throwCantPack("unexpected value in PE header (try --force)");
-    checkHeaderValues(ih.subsystem, subsystem_mask, ih.entry, ih.filealign);
+    checkHeaderValues(ih.subsystem, subsystem_mask, ih.entry, ih.filealign, ih.dllflags);
 
     //remove certificate directory entry
     if (IDSIZE(PEDIR_SEC))

--- a/src/pefile.h
+++ b/src/pefile.h
@@ -54,7 +54,8 @@ protected:
     unsigned readSections(unsigned objs, unsigned usize,
                           unsigned ih_filealign, unsigned ih_datasize);
     void checkHeaderValues(unsigned subsystem, unsigned mask,
-                           unsigned ih_entry, unsigned ih_filealign);
+                           unsigned ih_entry, unsigned ih_filealign,
+                           unsigned ih_dllflags);
     unsigned handleStripRelocs(upx_uint64_t ih_imagebase,
                                upx_uint64_t default_imagebase,
                                unsigned dllflags);
@@ -268,6 +269,7 @@ protected:
         IMAGE_DLLCHARACTERISTICS_NO_SEH                = 0x0400,
         IMAGE_DLLCHARACTERISTICS_NO_BIND               = 0x0800,
         IMAGE_DLLCHARACTERISTICS_WDM_DRIVER            = 0x2000,
+        IMAGE_DLLCHARACTERISTICS_CONTROL_FLOW_GUARD    = 0x4000,
         IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE = 0x8000
     };
 


### PR DESCRIPTION
Disable the compression of [Control Flow Guard](https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard) enabled PE files (compressed files don't run : #154, #203, #250, #398 - uncompressed with `-d` also fail to run), by introducing and checking the status of `CONTROL FLOW GUARD` bit of the `DLL CHARACTERISTICS` flag.