### PR TITLE
PE: only add a TLS relocation if tls_handler_offset_reloc != 0

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1377,7 +1377,7 @@ void PeFile::processTls2(Reloc *rel,const Interval *iv,unsigned newaddr,
         return;
     // add new relocation entries
 
-    if __acc_cte(tls_handler_offset_reloc > 0)
+    if __acc_cte(tls_handler_offset > 0 && tls_handler_offset_reloc > 0)
         rel->add(tls_handler_offset + tls_handler_offset_reloc, reloc_type);
 
     unsigned ic;


### PR DESCRIPTION
See #83 and #338 (same bug). Symptoms: PE file will crash at load with a status `0xC0000005`) (`STATUS_ACCESS_VIOLATION` / segfault). #83 contains the `dumpbin` output of a UPX 3.96-compressed binary with a TLS directory, where some of the relocations are clearly wrong:

UPX 3.91 (correct):
```
BASE RELOCATIONS #3
   17000 RVA,       18 SizeOfBlock
      BD  HIGHLOW            1000F000
     28C  HIGHLOW            100172A4
     290  HIGHLOW            100172AC
     294  HIGHLOW            10012804
     2E8  HIGHLOW            10012068
     2EC  HIGHLOW            1000FD00
     2F4  HIGHLOW            1000E258
       0  ABS               
```

UPX 3.96 (bogus):
```
BASE RELOCATIONS #3
       0 RVA,        C SizeOfBlock
       4  HIGHLOW            00000000
       0  ABS                        
   17000 RVA,       18 SizeOfBlock
     22D  HIGHLOW            1000F000
     3FC  HIGHLOW            10017414
     400  HIGHLOW            1001741C
     404  HIGHLOW            10012804
     458  HIGHLOW            10012068
     45C  HIGHLOW            1000FD00
     464  HIGHLOW            1000E258
       0  ABS      
```

#338 contains a handy zip file to reproduce the issue by trying to load a UPX'd DLL more than once, which fails with 3.96 compressed files but succeeds with files compressed with older versions.

Adding the simple sanity check that `tls_handler_offset` must not be 0 before adding the relocation fixes this issue and results in a proper relocation directory. The target executables work fine, so I will tentatively assume no actual useful information is lost by doing this.