### PR TITLE
PackHeader::fillPackHeader() more thorough checking of header size to avoid overflow reads

### DIFF
--- a/src/packhead.cpp
+++ b/src/packhead.cpp
@@ -245,7 +245,7 @@ bool PackHeader::fillPackHeader(const upx_bytep buf, int blen) {
     }
 
     if (version >= 10) {
-        if (off_filter >  size_remaining) {
+        if (off_filter >=  size_remaining) {
           throwCantUnpack("header corrupted 10");
         }
         filter = p[off_filter];


### PR DESCRIPTION
The logic at present uses the getPackHeaderSize() to ensure that the buffer contains enough data to read the different header sizes. However, this function uses the version and format to decide the header length; but parsing of the header only considers the format.
As a result, an ill-formed header (eg version == 0) will pass the getPackHeaderSize() but then read more bytes when it decodes the header.

The code here explicitly checks size of the buffer before reads.

Side note: there is lots of duplication of these "magic" sizes between fillPackHeader(), getPackHeaderSize() and putPackHeader(). It would be nice to create some constants to define these but that is out of scope for this PR.

Fixes: https://github.com/upx/upx/issues/414