### PR TITLE
Migrate to MemBuffer to remove mem leak

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1729,7 +1729,7 @@ void PeFile::Resource::build(const upx_rnode *node, unsigned &bpos,
     }
 }
 
-upx_byte* PeFile::Resource::build()
+upx_byte *PeFile::Resource::build()
 {
     mem.dealloc();
     newstart = nullptr;

--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1729,16 +1729,21 @@ void PeFile::Resource::build(const upx_rnode *node, unsigned &bpos,
     }
 }
 
-upx_byte *PeFile::Resource::build()
+upx_byte* PeFile::Resource::build()
 {
-    newstart = New(upx_byte, dirsize());
-    unsigned bpos = 0,spos = dsize;
-    build(root,bpos,spos,0);
+    mem.dealloc();
+    newstart = nullptr;
+    if (dirsize()) {
+      mem.alloc(dirsize());
+      newstart = static_cast<upx_byte *>(mem.getVoidPtr());
+      unsigned bpos = 0,spos = dsize;
+      build(root,bpos,spos,0);
 
-    // dirsize() is 4 bytes aligned, so we may need to zero
-    // up to 2 bytes to make valgrind happy
-    while (spos < dirsize())
-        newstart[spos++] = 0;
+      // dirsize() is 4 bytes aligned, so we may need to zero
+      // up to 2 bytes to make valgrind happy
+      while (spos < dirsize())
+          newstart[spos++] = 0;
+    }
 
     return newstart;
 }
@@ -1825,9 +1830,10 @@ void PeFile::processResources(Resource *res,unsigned newaddr)
     while (res->next())
         if (res->newoffs())
             res->newoffs() += newaddr;
-    upx_byte *p = res->build();
-    memcpy(oresources,p,res->dirsize());
-    delete [] p;
+    if (res->dirsize()) {
+      upx_byte *p = res->build();
+      memcpy(oresources,p,res->dirsize());
+    }
 }
 
 static bool match(unsigned itype, const unsigned char *ntype,
@@ -2757,12 +2763,13 @@ void PeFile::rebuildResources(upx_byte *& extrainfo, unsigned lastvaddr)
                 icondir_count = 0;
             }
         }
-    upx_byte *p = res.build();
-    OCHECK(obuf + ODADDR(PEDIR_RESOURCE) - rvamin, 16);
-    // write back when the original is zeroed
-    if (get_le32(obuf + ODADDR(PEDIR_RESOURCE) - rvamin + 12) == 0)
+    if (res.dirsize()) {
+      upx_byte *p = res.build();
+      OCHECK(obuf + ODADDR(PEDIR_RESOURCE) - rvamin, 16);
+      // write back when the original is zeroed
+      if (get_le32(obuf + ODADDR(PEDIR_RESOURCE) - rvamin + 12) == 0)
         omemcpy(obuf + ODADDR(PEDIR_RESOURCE) - rvamin, p, res.dirsize());
-    delete [] p;
+    }
 }
 
 template <typename LEXX, typename ord_mask_t>

--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1731,11 +1731,11 @@ void PeFile::Resource::build(const upx_rnode *node, unsigned &bpos,
 
 upx_byte *PeFile::Resource::build()
 {
-    mem.dealloc();
+    mb_start.dealloc();
     newstart = nullptr;
     if (dirsize()) {
-      mem.alloc(dirsize());
-      newstart = static_cast<upx_byte *>(mem.getVoidPtr());
+      mb_start.alloc(dirsize());
+      newstart = static_cast<upx_byte *>(mb_start.getVoidPtr());
       unsigned bpos = 0,spos = dsize;
       build(root,bpos,spos,0);
 

--- a/src/pefile.h
+++ b/src/pefile.h
@@ -343,7 +343,7 @@ protected:
         struct upx_rbranch;
         struct upx_rleaf;
 
-        MemBuffer mem;
+        MemBuffer mb_start;
         const upx_byte *start;
         upx_byte   *newstart;
         upx_rnode  *root;

--- a/src/pefile.h
+++ b/src/pefile.h
@@ -29,6 +29,8 @@
 #ifndef __UPX_PEFILE_H
 #define __UPX_PEFILE_H 1
 
+#include "mem.h"
+
 
 /*************************************************************************
 // general/pe handling
@@ -341,6 +343,7 @@ protected:
         struct upx_rbranch;
         struct upx_rleaf;
 
+        MemBuffer mem;
         const upx_byte *start;
         upx_byte   *newstart;
         upx_rnode  *root;


### PR DESCRIPTION
As suggested in #428.

There are plenty of other use of new(), doing this one first as a proof-of-concept.