### PR TITLE
reset done_output_name counter upx_main()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1409,6 +1409,7 @@ int upx_main(int argc, char *argv[]) {
     static char default_argv0[] = "upx";
 
     upx_compiler_sanity_check();
+    done_output_name = 0;
     opt->reset();
 
     if (!argv[0] || !argv[0][0])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1409,6 +1409,7 @@ int upx_main(int argc, char *argv[]) {
     static char default_argv0[] = "upx";
 
     upx_compiler_sanity_check();
+    // allow serial re-use of main() as a subroutine
     done_output_name = 0;
     opt->reset();
 


### PR DESCRIPTION
Since, https://github.com/upx/upx/commit/36f2ff2fa0c2483f7fd86deb16f20cb33eb4af92, it is possible to use UPX as a library - it can be called by another main().
This patch fixes a limitation to that. Currently the done_output_name counter ensures that the output name can be set only once. This patch resets the counter at the beginning of each call to upx_main(), as per the options that are reset.

Side note: perhaps this could be changed to a bool, but I'll leave that to authors with more experience to know if that is suitable.