### PR TITLE
Don't compress PE files with overlapping MZ header

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -174,6 +174,8 @@ int PeFile::readFileHeader()
                 throwCantPack(buf);
             }
             pe_offset += delta;
+            if (pe_offset < sizeof(h))
+                throwCantPack("MZ/PE headers overlap");
         }
         else if (get_le32(&h) == 'P' + 'E'*256)
             break;


### PR DESCRIPTION
Fixes #231.