### PR TITLE
PE: fix SizeOfHeaders value of Optional Header field

### DIFF
--- a/src/p_w32pe.cpp
+++ b/src/p_w32pe.cpp
@@ -278,8 +278,7 @@ void PackW32Pe::setOhDataBase(const pe_section_t *osection)
 
 void PackW32Pe::setOhHeaderSize(const pe_section_t *osection)
 {
-    (void)osection;
-    oh.headersize = rvamin;  // FIXME
+    oh.headersize = ALIGN_UP(pe_offset + sizeof(oh) + sizeof(osection) * oh.objects, oh.filealign);
 }
 
 void PackW32Pe::pack(OutputFile *fo)

--- a/src/p_w64pep.cpp
+++ b/src/p_w64pep.cpp
@@ -266,12 +266,6 @@ void PackW64Pep::defineSymbols(unsigned ncsection, unsigned upxsection,
     linker->defineSymbol("START", upxsection);
 }
 
-void PackW64Pep::setOhHeaderSize(const pe_section_t *osection)
-{
-    (void)osection;
-    oh.headersize = rvamin;  // FIXME
-}
-
 void PackW64Pep::pack(OutputFile *fo)
 {
     // FIXME: Relocation stripping disabled for now - Stefan Widmann

--- a/src/p_w64pep.h
+++ b/src/p_w64pep.h
@@ -51,7 +51,7 @@ public:
                                unsigned sizeof_oh, unsigned isize_isplit,
                                unsigned s1addr);
     virtual void setOhDataBase(const pe_section_t *) {}
-    virtual void setOhHeaderSize(const pe_section_t *osection);
+    virtual void setOhHeaderSize(const pe_section_t *) {}
     virtual void pack(OutputFile *fo);
 
     virtual bool canPack();

--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -2997,9 +2997,7 @@ void PeFile::unpack0(OutputFile *fo, const ht &ih, ht &oh,
     ODADDR(PEDIR_BOUNDIM) = 0;
     ODSIZE(PEDIR_BOUNDIM) = 0;
 
-    // oh.headersize = osection[0].rawdataptr;
-    // oh.headersize = ALIGN_UP(pe_offset + sizeof(oh) + sizeof(pe_section_t) * objs, oh.filealign);
-    oh.headersize = rvamin;
+    setOhHeaderSize(osection);
     oh.chksum = 0;
 
     // write decompressed file


### PR DESCRIPTION
Fix the value of SizeOfHeader (`oh.headerzise`) of the PE Optional Header field (offset 0x3c), to have *the combined size of the MS-DOS stub, PE header, and section headers rounded up to a multiple of FileAlignment*, instead of `rvamin` (FIXME).