### PR TITLE
PE: fix SectionHeadersSize of SizeOfHeaders value

### DIFF
--- a/src/p_w32pe.cpp
+++ b/src/p_w32pe.cpp
@@ -278,7 +278,7 @@ void PackW32Pe::setOhDataBase(const pe_section_t *osection)
 
 void PackW32Pe::setOhHeaderSize(const pe_section_t *osection)
 {
-    oh.headersize = ALIGN_UP(pe_offset + sizeof(oh) + sizeof(osection) * oh.objects, oh.filealign);
+    oh.headersize = ALIGN_UP(pe_offset + sizeof(oh) + sizeof(*osection) * oh.objects, oh.filealign);
 }
 
 void PackW32Pe::pack(OutputFile *fo)


### PR DESCRIPTION
There was an error in #477 which wasn't obvious due to alignment. Sorry about that.