### PR TITLE
Fix unoptimizeReloc() to process all relocs

### DIFF
--- a/src/packer.cpp
+++ b/src/packer.cpp
@@ -892,7 +892,7 @@ unsigned Packer::unoptimizeReloc(upx_byte **in, upx_byte *image, MemBuffer *out,
             jc += dif;
         }
         *relocs++ = jc; // FIXME: range check jc
-        if (!--relocn) {
+        if (!relocn--) {
             break;
         }
         if (bswap && image) {


### PR DESCRIPTION
Fix relocs rebuild by checking `relocn` in `unoptimizeReloc()` before (instead of after) decreasing its value in the loop. This fixes unpacking of certain files like this [test-relocs.exe.gz](https://github.com/upx/upx/files/6353736/test-relocs.exe.gz).
Test by:
- Run `test-relocs.exe`: the program runs ok.
- Compress and run: the program runs ok.
- Unpack and run: the program runs but with noticeable delay (`.CRT` section issue).
- Compress again and run: the program fails to run.
