### PR TITLE
Only enable -Wzero-as-null-pointer-constant with glibc

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -82,7 +82,7 @@ ACC_COMPILE_TIME_ASSERT_HEADER(CHAR_MAX == 255) // -funsigned-char
 ACC_COMPILE_TIME_ASSERT_HEADER((char)(-1) > 0) // -funsigned-char
 
 // enable/disable some warnings
-#if (ACC_CC_GNUC >= 0x040700)
+#if (ACC_CC_GNUC >= 0x040700) && defined(__GLIBC__)
 #  pragma GCC diagnostic error "-Wzero-as-null-pointer-constant"
 #endif
 #if (ACC_CC_MSC)


### PR DESCRIPTION
As far as I observe, gcc-11.2.0+musl can't build with this option.