### PR TITLE
Revert `-std=c++14`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ CXXFLAGS_WERROR ?= -Werror
 
 # Mandatory Flags - DO NOT CHANGE!
 mf.CPPFLAGS += $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES)
+mf.CXXFLAGS += -std=c++14
 mf.CXXFLAGS += $(CXXFLAGS_OPTIMIZE)
 # protect against security threats caused by misguided C++ compiler "optimizations"
 mf.CXXFLAGS += $(CXXFLAGS_NO_DELETE_NULL_POINTER_CHECKS)


### PR DESCRIPTION
This commit reverts 648fa30f22ae195f591210d7d2fa264e69b233ae which was removed by d60c46371dc011808c253ca664539835fb0a9e02 which is fixed https://github.com/upx/upx/issues/440