### PR TITLE
Update pefile.cpp to fix a crash

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -2165,7 +2165,10 @@ void PeFile::checkHeaderValues(unsigned subsystem, unsigned mask,
     //check CLR Runtime Header directory entry
     if (IDSIZE(PEDIR_COMRT))
         throwCantPack(".NET files are not yet supported");
-
+  
+    if(isection == NULL)
+        throwCantPack("No section was found");
+    
     if (memcmp(isection[0].name,"UPX",3) == 0)
         throwAlreadyPackedByUPX();
 


### PR DESCRIPTION
I found a bug by participating to the Binary Golf Grand Prix 3 (https://tmpout.sh/bggp/3/) : upx text.exe segfaults when NumberOfSections in the IMAGE_FILE_HEADER is NULL, so 
if (memcmp(isection[0].name,"UPX",3) == 0) triggers a NULL pointer dereference causing a crash.
To fix it, just have to check if isection is NULL (which means NumberOfSections = 0) or not.