### PR TITLE
fix: missing header file in musl-base system

### DIFF
--- a/src/util/dt_check.cpp
+++ b/src/util/dt_check.cpp
@@ -25,6 +25,7 @@
    <markus@oberhumer.com>               <ezerotven+github@gmail.com>
  */
 
+#include <cstdint>
 #include "../conf.h"
 
 /*************************************************************************


### PR DESCRIPTION
Under musl-based linux systems, such as `Alpine`, unlike glibc, they do not have `intmax_t` and `uintmax_t` types by default, which will cause compilation errors:

```
/root/upx/src/util/dt_check.cpp: In function 'void DOCTEST_ANON_FUNC_8()':
/root/upx/src/util/dt_check.cpp:410:5: error: 'intmax_t' was not declared in this scope
  410 |     intmax_t im = ll;
      |     ^~~~~~~~
/root/upx/src/util/dt_check.cpp:411:5: error: 'uintmax_t' was not declared in this scope; did you mean 'uint64_t'?
  411 |     uintmax_t um = llu;
      |     ^~~~~~~~~
      |     uint64_t
```

So we must include the `stdint.h` or `cstdint` header file to specify the `intmax_t` and `uintmax_t` types to the compiler.