### PR TITLE
Increase number of lc segment present in macho file

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -1515,7 +1515,7 @@ void PackMachBase<T>::unpack(OutputFile *fo)
     ||  mhdri.filetype   != mhdr->filetype)
         throwCantUnpack("file header corrupted");
     unsigned const ncmds = mhdr->ncmds;
-    if (!ncmds || 24 < ncmds) { // arbitrary limit
+    if (!ncmds || 48 < ncmds) { // arbitrary limit
         char msg[40]; snprintf(msg, sizeof(msg),
             "bad Mach_header.ncmds = %d", ncmds);
         throwCantUnpack(msg);


### PR DESCRIPTION
Increase number of load commands from 24 to 48 as many files have more than 24 lc segments.

UPX PULL REQUEST NOTES
======================

Handling pull requests is actually quite time consuming, so please

- if you want to contribute **a real C++ code bug-fix** then open an issue
on the main UPX issue tracker first

- if you want to contribute **a new feature** then by all means open an issue
on the main UPX issue tracker first before starting any coding!

- please refuse the temptation to "improve" the docs, scripts, CI, makefiles,
cmake build system, spelling errors, etc - we will NOT merge this; only open
an issue if you're sure there is a **real bug**
