### PR TITLE
Fix bug #863

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1224,6 +1224,10 @@ void PeFile::Export::convert(unsigned eoffs, unsigned esize) {
     size += len;
     iv.add_interval(edir.name, len);
 
+    if (upx_uint64_t(edir.functions + edir.names) * 4 >= upx_uint64_t(esize)) {
+        throwInternalError("bad export directory, outside size");
+    }
+
     len = 4 * edir.functions;
     functionptrs = New(char, len + 1);
     memcpy(functionptrs, base + edir.addrtable, len);

--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -1224,7 +1224,9 @@ void PeFile::Export::convert(unsigned eoffs, unsigned esize) {
     size += len;
     iv.add_interval(edir.name, len);
 
-    if (upx_uint64_t(edir.functions + edir.names) * 4 >= upx_uint64_t(esize)) {
+    // this check does not take UPX_RSIZE_MAX_MEM into account
+    const int ptr_size = 4; // size of function/name pointers
+    if ((upx_uint64_t(edir.functions) + upx_uint64_t(edir.names)) * ptr_size >= upx_uint64_t(esize - sizeof(export_dir_t))) {
         throwInternalError("bad export directory, outside size");
     }
 


### PR DESCRIPTION
Updated the patch with things pointed out by jreiser on review of the patch.
    - Fix type conversion issue
    - Added constant with comment
    - Added comment for not validating UPX_RSIZE_MAX_MEM
    
    Additional changes
    - Honor the size of the export_dir_t when calculating the available
      space
