### PR TITLE
Disable 'PEDIR_EXCEPTION' check for .NET Core NativeAOT on x86

### DIFF
--- a/src/p_w32pe_i386.cpp
+++ b/src/p_w32pe_i386.cpp
@@ -150,7 +150,9 @@ bool PackW32PeI386::needForceOption() const {
     r |= (ih.coffmagic != 0x10b);                      // COFF magic is 0x10B in PE files
     r |= (ih.entry == 0 && !isdll);
     r |= (ih.ddirsentries != 16);
-    r |= (IDSIZE(PEDIR_EXCEPTION) != 0); // is this used on i386?
+    // Explanation: For .NET Core NativeAOT on x86, an exception directory is expected.
+    // Disabling this check prevents `--force` from being erroneously required.
+    //// r |= (IDSIZE(PEDIR_EXCEPTION) != 0);
     //// r |= (IDSIZE(PEDIR_COPYRIGHT) != 0);
     return r;
 }


### PR DESCRIPTION
In .NET Core NativeAOT scenarios targeting x86, an exception directory is normal.
This check forces the --force option unnecessarily whenever an exception directory
is present. Commenting out the check ensures valid NativeAOT executables aren't
incorrectly flagged for forced packing.

[dotNetAotTest.zip](https://github.com/user-attachments/files/19127243/dotNetAotTest.zip)

UPX PULL REQUEST NOTES
======================

Handling pull requests is actually quite time consuming, so please

- if you want to contribute **a real C++ code bug-fix** then open an issue
on the main UPX issue tracker first

- if you want to contribute **a new feature** then by all means open an issue
on the main UPX issue tracker first before starting any coding!

- please refuse the temptation to "improve" the docs, scripts, CI, makefiles,
cmake build system, spelling errors, etc - we will NOT merge this; only open
an issue if you're sure there is a **real bug**
