### PR TITLE
pack ELF64: fix PLT section name for SHT_RELA in pack3

### DIFF
--- a/src/p_lx_elf.cpp
+++ b/src/p_lx_elf.cpp
@@ -926,7 +926,7 @@ off_t PackLinuxElf64::pack3(OutputFile *fo, Filter &ft)
                 }
                 if (Elf64_Shdr::SHT_RELA == sh_type
                 &&  n_jmp_slot  // FIXME: does this apply to SHT_RELA ?
-                &&  !strcmp(".rel.plt", get_te32(&shdr->sh_name) + shstrtab)) {
+                &&  !strcmp(".rela.plt", get_te32(&shdr->sh_name) + shstrtab)) {
                     u64_t va = elf_unsigned_dynamic(Elf64_Dyn::DT_PLTGOT) - (is_asl ? asl_delta : 0);
                     // Now use the old Phdrs (phdri)
                     Elf64_Phdr const *phva;


### PR DESCRIPTION
When matching the dynamic PLT relocation section, compare against .rela.plt for SHT_RELA, not .rel.plt.

UPX PULL REQUEST NOTES
======================

Handling pull requests is actually quite time consuming, so please

- if you want to contribute **a real C++ code bug-fix** then open an issue
on the main UPX issue tracker first

- if you want to contribute **a new feature** then by all means open an issue
on the main UPX issue tracker first before starting any coding!

- please refuse the temptation to "improve" the docs, scripts, CI, makefiles,
cmake build system, spelling errors, etc - we will NOT merge this; only open
an issue if you're sure there is a **real bug**
