### PR TITLE
pefile: keep PETLSHAK for DLLs to preserve loader-assigned TLS index

### DIFF
--- a/src/p_w32pe_i386.cpp
+++ b/src/p_w32pe_i386.cpp
@@ -91,7 +91,9 @@ void PackW32PeI386::buildLoader(const Filter *ft) {
     unsigned tmp_tlsindex = tlsindex;
     const unsigned oam1 = ih.objectalign - 1;
     const unsigned newvsize = (ph.u_len + rvamin + ph.overlap_overhead + oam1) & ~oam1;
-    if (tlsindex && ((newvsize - ph.c_len - 1024 + oam1) & ~oam1) > tlsindex + 4)
+    // keep PETLSHAK for DLLs: the loader sets the tls index after
+    // LoadLibrary, so it must survive decompression
+    if (tlsindex && !isdll && ((newvsize - ph.c_len - 1024 + oam1) & ~oam1) > tlsindex + 4)
         tmp_tlsindex = 0;
 
     // prepare loader

--- a/src/p_w64pe_amd64.cpp
+++ b/src/p_w64pe_amd64.cpp
@@ -81,7 +81,9 @@ void PackW64PeAmd64::buildLoader(const Filter *ft) {
     unsigned tmp_tlsindex = tlsindex;
     const unsigned oam1 = ih.objectalign - 1;
     const unsigned newvsize = (ph.u_len + rvamin + ph.overlap_overhead + oam1) & ~oam1;
-    if (tlsindex && ((newvsize - ph.c_len - 1024 + oam1) & ~oam1) > tlsindex + 4)
+    // keep PETLSHAK for DLLs: the loader sets the tls index after
+    // LoadLibrary, so it must survive decompression
+    if (tlsindex && !isdll && ((newvsize - ph.c_len - 1024 + oam1) & ~oam1) > tlsindex + 4)
         tmp_tlsindex = 0;
 
     // prepare loader

--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -2486,7 +2486,9 @@ void PeFile::pack0(OutputFile *fo, ht &ih, ht &oh, unsigned subsystem_mask,
     callCompressWithFilters(ft, filter_strategy, ih.codebase);
     // info: see buildLoader()
     newvsize = (ph.u_len + rvamin + ph.overlap_overhead + oam1) & ~oam1;
-    if (tlsindex && ((newvsize - ph.c_len - 1024 + oam1) & ~oam1) > tlsindex + 4)
+    // but keep PETLSHAK for DLLs: the loader sets the tls index after
+    // LoadLibrary, so it must survive decompression
+    if (tlsindex && !isdll && ((newvsize - ph.c_len - 1024 + oam1) & ~oam1) > tlsindex + 4)
         tlsindex = 0;
 
     const int oh_filealign = UPX_MIN(ih.filealign, 0x200u);


### PR DESCRIPTION
Fixes #18854.

I develop a Total Commander WLX plugin. It is a Markdown viewer that embeds WebView2 - a 32-bit DLL, static CRT (`/MT`), MSVC, loaded by Total Commander via `LoadLibrary` well after process init. UPX-packed it crashes; unpacked it works, and `upx -d` of the packed DLL works again, so the fault is purely the UPX transform. A crash dump showed a null object reached through a function-local `static` (a Meyers singleton); `_tls_index` was 0 in the packed DLL, where a late-loaded DLL should have a nonzero loader-assigned slot. The unpacked DLL had a correct nonzero `_tls_index`.

**Root cause.** `pack0()` and `buildLoader()` set `tlsindex = 0` and omit `PETLSHAK`/`PETLSHAK2` when the index variable falls in the decompressed region. For a `LoadLibrary`'d DLL the loader's `LdrpHandleTlsData` has already written a real nonzero index to `*AddressOfIndex` before the stub runs; with `PETLSHAK` omitted, decompression overwrites it with the zeroed file value and nothing restores it.

**Fix.** Add `!isdll` to the three identical gates. `PETLSHAK`/`PETLSHAK2` already save the runtime `*tlsindex` before decompression and restore it after, so keeping them active for DLLs preserves the loader-assigned index. The EXE path is byte-identical (EXEs still take `tmp_tlsindex = 0` exactly as before), and the `buildLoader()`/`pack0()` consistency added in 6a7d555 is preserved (both sites gated identically, plus the amd64 sibling).

**Testing.** Deterministic C + CMake repro in #18854: unpacked -> `_tls_index != 0`, PASS; stock UPX 5.1.1 -> `_tls_index = 0`, FAIL; patched UPX -> PASS. `upx -t` OK on the packed DLL; an EXE-with-TLS still packs and tests OK (the `isdll == false` path is unchanged).
