### PR TITLE
pefile: align imagesize after removing .reloc section

### DIFF
--- a/src/pefile.cpp
+++ b/src/pefile.cpp
@@ -524,7 +524,10 @@ void PeFile32::processRelocs() { // pass1
             if (old_objs != ih.objects && 1) { // was removed
                 IDADDR(PEDIR_BASERELOC) = 0;
                 IDSIZE(PEDIR_BASERELOC) = 0;
-                ih.imagesize = isection[-1 + ih.objects].vsize + isection[-1 + ih.objects].vaddr;
+                const unsigned oam1 = ih.objectalign - 1;
+                ih.imagesize =
+                    (isection[-1 + ih.objects].vsize + isection[-1 + ih.objects].vaddr + oam1) &
+                    ~oam1;
             }
         }
         mb_orelocs.alloc(1);
@@ -632,7 +635,10 @@ void PeFile64::processRelocs() { // pass1
             if (old_objs != ih.objects && 1) { // was removed
                 IDADDR(PEDIR_BASERELOC) = 0;
                 IDSIZE(PEDIR_BASERELOC) = 0;
-                ih.imagesize = isection[-1 + ih.objects].vsize + isection[-1 + ih.objects].vaddr;
+                const unsigned oam1 = ih.objectalign - 1;
+                ih.imagesize =
+                    (isection[-1 + ih.objects].vsize + isection[-1 + ih.objects].vaddr + oam1) &
+                    ~oam1;
             }
         }
         mb_orelocs.alloc(1);


### PR DESCRIPTION
Fixes #951.

When relocations are stripped (the default for non-ASLR executables), `PeFile::processRelocs()` removes the `.reloc` section and recomputes `ih.imagesize` from the last remaining section without rounding up to `objectalign`. The resulting `SizeOfImage` is not a multiple of `SectionAlignment`, so `upx -d` produces an image that the Windows loader rejects on both 32-bit and 64-bit.

The unaligned recompute became live with f0a89504 ("pefile: really remove .reloc section if no relocs"), which enabled the section removal that was previously a no-op. Round `imagesize` up to `objectalign`, as is done at the other `imagesize` assignments.

Test with the Watcom-linked PE32 files from the issue (`ncopy.exe`, `cpusage.exe`, `cpcvt.exe`):
- `upx file.exe && upx -d file.exe`
- Before: decompressed `SizeOfImage` is unaligned (e.g. `0x9ae0`) — invalid PE.
- After: aligned (`0xa000`) — the decompressed file is a valid image again.
