### PR TITLE
CP/M-86: size header data group to buffer size

### DIFF
--- a/src/p_cpm86.cpp
+++ b/src/p_cpm86.cpp
@@ -418,12 +418,10 @@ void PackCpm86::pack(OutputFile *fo) {
         set_le16(d + 5, code_alloc_ip);   // min = inflated (room to stage code + copyr)
         set_le16(d + 7, code_alloc_ip);   // max
         d = hdr + slot++ * GD_SIZE;
-        d[0] = GT_DATA;     // length 0; max sized to the decompress buffer (the loader
-        set_le16(d + 1, 0); // gives 64K when max==0, else exactly max paragraphs)
-        if (data_alloc_ip < 0x1000) {
-            set_le16(d + 5, data_alloc_ip);
-            set_le16(d + 7, data_alloc_ip);
-        }
+        d[0] = GT_DATA; // length 0; the stub fills it from the decompressed image
+        set_le16(d + 1, 0);
+        set_le16(d + 5, data_alloc_ip);
+        set_le16(d + 7, data_alloc_ip);
         if (grp_extra) {
             d = hdr + slot++ * GD_SIZE;
             d[0] = GT_EXTRA;


### PR DESCRIPTION
Always use non-zero min/max filled by the stub explicitly instead of using the "max=0 is 64K" convention in the CMD header. Most honor valid max=0 as 64K, but some CP/M-86 CMD loaders (such as the Jim Lopushinsky emulator for MS-DOS, and some dev tools that load these files reject a group with G-min and G-max both zero with "Invalid .CMD file header".

The data_alloc_ip is capped at 0x1000 (a full 64K group), which any loader accepts.  No packed data changes at all, just the header detail, and the new info is exactly equivalent, just a different representation.  No other testers from the big influx of six found other issues.

Thanks to Neville T. Miller for very quickly reporting and testing.

```
 src/p_cpm86.cpp                                 | 10 ++++------
 1 file changed, 4 insertions(+), 6 deletions(-)
```

Signed-off-by: Jeffrey H. Johnson \<johnsonjh.dev@gmail.com\>