### PR TITLE
CP/M-86: reject u_file_size larger than u_len in unpack

### DIFF
--- a/src/p_cpm86.cpp
+++ b/src/p_cpm86.cpp
@@ -497,8 +497,12 @@ void PackCpm86::unpack(OutputFile *fo) {
     decompress(ibuf + c_off, obuf);
 
     // ph.u_len may include padding past the real end of file; write only the
-    // original byte count for a lossless result.
+    // original byte count for a lossless result.  u_file_size is taken verbatim
+    // from the pack header and must not exceed u_len (the obuf size), else the
+    // write below would read past the decompression buffer.
     unsigned out_len = ph.u_file_size ? ph.u_file_size : ph.u_len;
+    if (out_len > ph.u_len)
+        throwCantUnpack("file damaged");
     if (fo)
         fo->write(obuf, out_len);
 }


### PR DESCRIPTION
1. unpack writes ph.u_file_size bytes from obuf, but obuf is sized to ph.u_len.
2. u_file_size is decoded from the pack header and never checked against u_len, so a crafted .cmd with u_file_size > u_len reads past the buffer during `upx -d` (heap over-read into the output, or a crash for large values).
Reject out_len > u_len before the write; the packer always stores u_file_size = file_size <= u_len, so a larger value is a damaged file.