### PR TITLE
Mach-O: validate __mod_init_func offset before 4-byte patch

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -924,6 +924,8 @@ void PackMachBase<T>::pack4dylib(  // append PackHeader
                 fi->readx(data, len);
                 unsigned const pos = o__mod_init_func - seg->fileoff;
                 if (pos < seg->filesize) {
+                    if (sizeof(unsigned) > (seg->filesize - pos))
+                        throwCantPack("bad __mod_init_func");
                     if (*(unsigned *)(pos + data) != (unsigned)prev_mod_init_func) {
                         throwCantPack("__mod_init_func inconsistent");
                     }
@@ -1607,7 +1609,10 @@ void PackMachBase<T>::unpack(OutputFile *fo)
                 MemBuffer data(len);
                 fi->readx(data, len);
                 if (!strcmp("__DATA", rc->segname)) {
-                    set_te32(&data[o__mod_init_func - rc->fileoff], unc_mod_init_func);
+                    unsigned const mif_off = o__mod_init_func - rc->fileoff;
+                    if (sizeof(unc_mod_init_func) > len || mif_off > len - sizeof(unc_mod_init_func))
+                        throwCantUnpack("bad __mod_init_func");
+                    set_te32(&data[mif_off], unc_mod_init_func);
                 }
                 if (fo)
                     fo->write(data, len);


### PR DESCRIPTION
In pack4dylib and unpack the __mod_init_func patch site is chosen with a single-position test (pos < seg->filesize on pack, the index check inside MemBuffer::operator[] on unpack), but the store touches four bytes through set_te32 / *(unsigned*), so a Mach-O whose __mod_init_func file offset sits within three bytes of the segment end writes past the heap buffer that holds the segment data. The offset is taken verbatim from the section header (o__mod_init_func = secptr->offset) and is never checked against the enclosing segment size. Reject the case where the four-byte field does not fit inside the segment before applying the patch.