### PR TITLE
bounds-check DT_INIT_ARRAY rp and dynsym in 32-bit un_DT_INIT

### DIFF
--- a/src/p_lx_elf.cpp
+++ b/src/p_lx_elf.cpp
@@ -7477,6 +7477,10 @@ void PackLinuxElf32::un_DT_INIT(
                 Elf32_Rel *rp = (Elf32_Rel *)elf_find_dynamic(dyn_null->d_val);
                 dyn_null->d_val = 0;
                 if (rp) {
+                    if ((char *)rp + sizeof(Elf32_Rel) > (char *)&file_image[0] + file_size_u)
+                        throwCantUnpack("bad DT_INIT_ARRAY relocation offset");
+                    if ((char *)&dynsym[1] > (char *)&file_image[0] + file_size_u)
+                        throwCantUnpack("bad dynsym for DT_INIT_ARRAY");
                     // Compressor saved the original *rp in dynsym[0]
                     Elf32_Rel *rp_unc = (Elf32_Rel *)&dynsym[0];  // pointer
                     rp->r_info = rp_unc->r_info;  // restore original r_info; r_offset not touched


### PR DESCRIPTION
1. In `PackLinuxElf32::un_DT_INIT` the DT_INIT_ARRAY/DT_PREINIT_ARRAY case takes `rp = elf_find_dynamic(dyn_null->d_val)` and `rp_unc = &dynsym[0]`, but `elf_find_dynamic` only verifies the start offset `t < file_size_u`, not `t + sizeof(struct)`.
2. A crafted 32-bit ELF can resolve `DT_NULL.d_val` (and the DT_SYMTAB address) into the last few bytes of `file_image`, so `rp->r_info = rp_unc->r_info` and the `dynsym[0]` accesses run past the end of the mapped file during `upx -d`.
3. `PackLinuxElf64::un_DT_INIT` already guards both pointers against `file_image + file_size_u`; added the same two checks to the 32-bit path so the inputs are rejected before the writes.