### PR TITLE
Mach-O: reject dylib unpack when ncmds disagrees with header copy

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -1584,6 +1584,10 @@ void PackMachBase<T>::unpack(OutputFile *fo)
     }
     Mach_segment_command const *sc = (Mach_segment_command const *)(void *)(1+ mhdr);
     if (my_filetype==Mach_header::MH_DYLIB) { // rest of lc_seg are not compressed
+        // rawmseg holds mhdri.ncmds load commands (canUnpack bounds-checked them),
+        // but the walk below counts with ncmds from the decompressed header
+        if (mhdri.ncmds != mhdr->ncmds)
+            throwCantUnpack("file header corrupted");
         upx_uint64_t cpr_mod_init_func(0);
                 TE32 unc_mod_init_func; *(int *)&unc_mod_init_func = 0;
         Mach_segment_command const *rc = rawmseg;


### PR DESCRIPTION
1. The MH_DYLIB branch of unpack walks rawmseg (the packed file's original load commands, sized mhdri.sizeofcmds and validated for mhdri.ncmds entries by canUnpack) using ncmds read from the decompressed header copy (mhdr->ncmds).
2. The preceding header check compares only magic/cputype/cpusubtype/filetype, so a crafted dylib whose compressed copy declares more commands than the file header steps rc past the end of rawmseg and reads rc->cmd/filesize/segname out of bounds during `upx -d`.
A genuine packed dylib stores the same header in both spots, so reject the file when the two ncmds disagree before the walk.