### PR TITLE
bound u_len and e_phnum in PackLinuxElf32x86interp::unpack

### DIFF
--- a/src/p_lx_interp.cpp
+++ b/src/p_lx_interp.cpp
@@ -229,10 +229,18 @@ void PackLinuxElf32x86interp::unpack(OutputFile *fo)
     ph.u_len = get_te32(&bhdr.sz_unc);
     ph.c_len = get_te32(&bhdr.sz_cpr);
     ph.filter_cto = bhdr.b_cto8;
+    // sz_unc/sz_cpr come straight from the packed file's b_info; the Ehdr+Phdrs
+    // decompress into the fixed-size u.buf[MAX_INTERP_HDR] on the stack, so the
+    // sibling ElfXX/Mach unpackers that size their output buffer to u_len don't
+    // overflow, but this one would. Bound u_len to the buffer.
+    if (ph.c_len == 0 || ph.u_len < sizeof(*ehdr) || ph.u_len > MAX_INTERP_HDR)
+        throwCantUnpack("b_info corrupted");
 
     // Uncompress Ehdr and Phdrs.
     fi->readx(ibuf, ph.c_len);
     decompress(ibuf, (upx_byte *)ehdr, false);
+    if ((ph.u_len - sizeof(*ehdr)) / sizeof(*phdr) < ehdr->e_phnum)
+        throwCantUnpack("bad compressed e_phnum");
 
     total_in = 0;
     total_out = 0;


### PR DESCRIPTION
1. PackLinuxElf32x86interp::unpack decompresses the first block (Ehdr plus Phdrs) into the fixed 512-byte stack buffer u.buf, using ph.u_len from the packed file b_info.sz_unc as the output length, so a crafted sz_unc above MAX_INTERP_HDR overflows the stack.
2. ehdr->e_phnum from that same decompressed block then drives the Phdr walk with no bound, reading past u.buf.
3. The sibling PackLinuxElf32/64::unpack and PackMachBase::unpack size their output buffer to u_len and bound e_phnum; this PT_INTERP path was the one that did neither, so I added both checks here.

Reached by upx -d --use-ptinterp on a crafted file. A genuine packed interp file keeps sz_unc = sizeof(Ehdr) + e_phnum*sizeof(Phdr) <= 512, so it is unaffected. Builds clean and the bounds match what the packer writes.