### PR TITLE
Revert "fix: reserve LC_CODE_SIGNATURE space for arm64 macOS Mach-O binaries"

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -1491,8 +1491,7 @@ void PackMachBase<T>::unpack(OutputFile *fo)
     fi->readx(rawmseg, mhdri.sizeofcmds);
 
     // FIXME forgot space left for LC_CODE_SIGNATURE;
-    if (is_arm64()) overlay_offset += 16384; // LC_CODE_SIGNATURE space
-     but canUnpack() sets overlay_offset anyway.
+    // but canUnpack() sets overlay_offset anyway.
     //overlay_offset = sizeof(mhdri) + mhdri.sizeofcmds + sizeof(linfo);
 
     fi->seek(overlay_offset, SEEK_SET);


### PR DESCRIPTION
Reverts upx/upx#18872