### PR TITLE
bound ph.u_len before extra_info tail reads in tmt/tos unpack

### DIFF
--- a/src/p_tmt.cpp
+++ b/src/p_tmt.cpp
@@ -286,7 +286,9 @@ void PackTmt::unpack(OutputFile *fo) {
     // decompress
     decompress(ibuf, obuf);
 
-    // read extra_info
+    // read extra_info from the tail of the decompressed image
+    if (ph.u_len < 8)
+        throwCantUnpack("file damaged");
     const unsigned orig_entry = mem_size(1, get_le32(obuf + ph.u_len - 8));
     const unsigned orelocsize = mem_size(1, get_le32(obuf + ph.u_len - 4));
     const unsigned osize = mem_size(1, ph.u_len - orelocsize);
@@ -296,8 +298,11 @@ void PackTmt::unpack(OutputFile *fo) {
         Filter ft(ph.level);
         ft.init(ph.filter, 0);
         ft.cto = (byte) ph.filter_cto;
-        if (ph.version < 11)
+        if (ph.version < 11) {
+            if (ph.u_len < 12)
+                throwCantUnpack("file damaged");
             ft.cto = (byte) (get_le32(obuf + ph.u_len - 12) >> 24);
+        }
         ft.unfilter(obuf, osize);
     }
 

--- a/src/p_tos.cpp
+++ b/src/p_tos.cpp
@@ -703,6 +703,10 @@ void PackTos::unpack(OutputFile *fo) {
     // decompress
     decompress(ibuf, obuf);
 
+    // the trailing FH_SIZE bytes hold the original file header
+    if (ph.u_len < FH_SIZE)
+        throwCantUnpack("file damaged");
+
     // write original header & decompressed file
     if (fo) {
         unsigned overlay = file_size_u - (FH_SIZE + ih.fh_text + ih.fh_data);


### PR DESCRIPTION
1. `PackTos::unpack` and `PackTmt::unpack` read the original file header / extra_info trailer from the end of the decompressed image as `obuf + ph.u_len - FH_SIZE` (p_tos.cpp) and `obuf + ph.u_len - 8/-4/-12` (p_tmt.cpp). `obuf` is a plain MemBuffer whose `operator+` bounds-checks the `+ ph.u_len` part, but the trailing `- N` is applied to the returned raw pointer and is not checked.
2. `decodePackHeaderFromBuf` only enforces `u_len >= 2`, so a crafted file passed to `upx -d` can set ph.u_len below the trailer size. For TOS this points the `FH_SIZE`-byte `fo->write(obuf + ph.u_len - FH_SIZE, FH_SIZE)` before the buffer (heap bytes leak into the output) and underflows `ph.u_len - FH_SIZE` to a huge write length; for TMT the `get_le32` trailer reads fall before the buffer.
3. Reject a u_len smaller than the trailer each unpacker reads (FH_SIZE for TOS; 8, and 12 on the pre-v11 filter path, for TMT) right after `decompress`. Only this layer knows the per-format trailer size, so the check belongs here rather than in the shared header decoder.