### PR TITLE
bound fixup object number in LeFile::countFixups

### DIFF
--- a/src/lefile.cpp
+++ b/src/lefile.cpp
@@ -290,11 +290,15 @@ void LeFile::countFixups(unsigned *counts) const {
             counts[o] += 9;
             // fall through
         case 7: // 32-bit offset
+            if (fix[4] == 0 || fix[4] > o)
+                throwCantPack("bad fixup object number");
             counts[fix[4] - 1] += 4;
             fix += (fix[1] & 0x10) ? 9 : 7;
             break;
         case 0x27: // 32-bit offset list
             ll = fix[2];
+            if (fix[3] == 0 || fix[3] > o)
+                throwCantPack("bad fixup object number");
             counts[fix[3] - 1] += ll * 4;
             fix += (fix[1] & 0x10) ? 6 : 4;
             fix += ll * 2;


### PR DESCRIPTION
1. countFixups reads the target object number from each fixup record (fix[4] for the 32-bit offset and 16:32 pointer records, fix[3] for the 32-bit offset list) and uses it as the index counts[obj - 1].
2. counts only holds objects + 2 entries, but the object number comes straight from the input file and is never range-checked, so object 0 (index wraps to 0xffffffff) or object > objects reads and writes past the allocation while packing an untrusted LE/LX file.
3. Reject an object number outside [1, objects] at both record sites before indexing counts.

Reproduced with ASAN on a crafted LE input: heap-buffer-overflow at lefile.cpp:293 in countFixups during `upx <file>`; after the change it stops with a clean CantPackException.