### PR TITLE
bound u_len and headway in macho unpack load-command walk

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -1512,7 +1512,7 @@ void PackMachBase<T>::unpack(OutputFile *fo)
     fi->readx(&bhdr, sizeof(bhdr));
     ph.u_len = get_te32(&bhdr.sz_unc);
     ph.c_len = get_te32(&bhdr.sz_cpr);
-    if ((unsigned)file_size < ph.c_len || ph.c_len == 0 || ph.u_len == 0)
+    if ((unsigned)file_size < ph.c_len || ph.c_len == 0 || ph.u_len < sizeof(mhdri))
         throwCantUnpack("file header corrupted");
     ph.method = bhdr.b_method;
     if (ph.method < M_NRV2B_LE32
@@ -1543,6 +1543,8 @@ void PackMachBase<T>::unpack(OutputFile *fo)
     unsigned char const *ptr = (unsigned char const *)(1+mhdr);
     unsigned headway = mhdr_buf.getSize() - sizeof(*mhdr);
     for (unsigned j= 0; j < ncmds; ++j) {
+        if (headway < sizeof(Mach_command))
+            throwCantUnpack("bad packed Mach load_command");
         unsigned cmdsize = ((Mach_command const *)ptr)->cmdsize;
         if (is_bad_linker_command( ((Mach_command const *)ptr)->cmd, cmdsize,
                 headway, lc_seg, sizeof(Addr))) {


### PR DESCRIPTION
1. PackMachBase::unpack takes ph.u_len from the file's b_info.sz_unc and only rejects u_len == 0, so a value below sizeof(Mach_header) leaves the magic/cputype/cpusubtype/filetype comparison reading past mhdr_buf, and headway = mhdr_buf.getSize() - sizeof(*mhdr) wraps because headway is unsigned.
2. the following load-command loop then reads ptr->cmd and ptr->cmdsize before is_bad_linker_command gets to check headway, so a crafted `upx -d` input causes an out-of-bounds read past the decompressed-header buffer.

Require u_len >= sizeof(Mach_header) and add the same `headway < sizeof(Mach_command)` check that canUnpack() and the pack-side walk already do before reading each command header.