### PR TITLE
bound disp probes in macho canUnpack folded-stub recovery

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -1807,6 +1807,9 @@ tribool PackMachBase<T>::canUnpack()
             unsigned disp = *(TE32 const *)&b[1];
             if (CPU_TYPE_X86_64 == my_cputype) { // Emulate the code
                 if (0xe8==b[0] && disp < bufsize
+                    // disp and the b_info that follow it are used as raw offsets
+                    // into buf3, which holds only bufsize bytes that were read.
+                    && (disp + 11 + sizeof(struct b_info)) <= bufsize
                     // This has been obsoleted by amd64-darwin.macho-entry.S
                     // searching for "executable_path=" etc.
                 &&  0x5d==b[5+disp] && 0xe8==b[6+disp]) {
@@ -1815,7 +1818,11 @@ tribool PackMachBase<T>::canUnpack()
                         struct b_info const *bptr = (struct b_info const *)&b[11+disp];
                         // This is the folded stub.
                         // FIXME: check b_method?
-                        if (bptr->sz_cpr < bptr->sz_unc && bptr->sz_unc < 0x1000) {
+                        if (bptr->sz_cpr < bptr->sz_unc && bptr->sz_unc < 0x1000
+                            // overlay_offset is read at (32 + b); keep that read
+                            // inside the bytes that were read into buf3.
+                        && ((11 + disp + sizeof(struct b_info) + (unsigned) bptr->sz_cpr)
+                                + 32 + sizeof(TE32)) <= bufsize) {
                             b = bptr->sz_cpr + (unsigned char const *)(1+ bptr);
                             // FIXME: check PackHeader::putPackHeader(), packhead.cpp
                             overlay_offset = *(TE32 const *)(32 + b);


### PR DESCRIPTION
1. The "try harder" recovery path in canUnpack (reached on `upx -d` of a Mach-O whose UPX marker is missing) reads a 4-byte displacement `disp` from the entry-point bytes and only checks `disp < bufsize`.
2. It then uses `disp` as a raw offset into `buf3`: `b[5+disp]`, `b[6+disp]`, the `b_info` at `&b[11+disp]`, and the overlay_offset read at `(32 + b)` after advancing `b` by `sz_cpr`. `buf3` holds only `bufsize` bytes, and neither `disp` nor `sz_cpr` is constrained to keep those fixed-offset reads inside it, so a crafted x86_64 Mach-O whose entry begins with `0xe8` and a `disp` close to `bufsize` reads past the allocation (AddressSanitizer reports a heap-buffer-overflow at the `b[5+disp]` read).
3. Bounded the fixed-offset probes and the sz_cpr-relative read to the bytes actually read into `buf3` before dereferencing.