### PR TITLE
bound DT_INIT_ARRAY relocation symbol index in canPack_Shdr

### DIFF
--- a/src/p_lx_elf.cpp
+++ b/src/p_lx_elf.cpp
@@ -2963,6 +2963,9 @@ upx_uint64_t PackLinuxElf32::canPack_Shdr(Elf32_Phdr const *pload_x0)
                         }
                         else if (R_ARM_ABS32 == r_type) {
                             unsigned symj = ELF32_R_SYM(r_info);
+                            if (symnum_max <= symj) {
+                                throwCantPack("bad symbol %#x in DT_INIT_ARRAY[0] relocation", symj);
+                            }
                             user_init_va = get_te32(&dynsym[symj].st_value);
                             set_te32(&rp->r_info, ELF32_R_INFO(0, R_ARM_RELATIVE));
                             // pack3() will set &file_image[user_init_off]
@@ -2977,6 +2980,9 @@ upx_uint64_t PackLinuxElf32::canPack_Shdr(Elf32_Phdr const *pload_x0)
                         }
                         else if (R_386_32 == r_type) {
                             unsigned symj = ELF32_R_SYM(r_info);
+                            if (symnum_max <= symj) {
+                                throwCantPack("bad symbol %#x in DT_INIT_ARRAY[0] relocation", symj);
+                            }
                             user_init_va = get_te32(&dynsym[symj].st_value);
                             set_te32(&rp->r_info, ELF32_R_INFO(0, R_386_RELATIVE));
                             // pack3() will set &file_image[user_init_off]
@@ -3105,7 +3111,11 @@ upx_uint64_t PackLinuxElf64::canPack_Shdr(Elf64_Phdr const *pload_x0)
                             user_init_va = get_te64(&rp->r_addend);
                         }
                         else if (R_AARCH64_ABS64 == r_type) {
-                            user_init_va = get_te64(&dynsym[ELF64_R_SYM(r_info)].st_value);
+                            unsigned const symj = ELF64_R_SYM(r_info);
+                            if (symnum_max <= symj) {
+                                throwCantPack("bad symbol %#x in DT_INIT_ARRAY[0] relocation", symj);
+                            }
+                            user_init_va = get_te64(&dynsym[symj].st_value);
                         }
                         else {
                             char msg[50]; snprintf(msg, sizeof(msg),
@@ -3119,7 +3129,11 @@ upx_uint64_t PackLinuxElf64::canPack_Shdr(Elf64_Phdr const *pload_x0)
                             user_init_va = get_te64(&rp->r_addend);
                         }
                         else if (R_RISCV_64 == r_type) {
-                            user_init_va = get_te64(&dynsym[ELF64_R_SYM(r_info)].st_value);
+                            unsigned const symj = ELF64_R_SYM(r_info);
+                            if (symnum_max <= symj) {
+                                throwCantPack("bad symbol %#x in DT_INIT_ARRAY[0] relocation", symj);
+                            }
+                            user_init_va = get_te64(&dynsym[symj].st_value);
                         }
                         else {
                             char msg[50]; snprintf(msg, sizeof(msg),
@@ -3133,7 +3147,11 @@ upx_uint64_t PackLinuxElf64::canPack_Shdr(Elf64_Phdr const *pload_x0)
                             user_init_va = get_te64(&rp->r_addend);
                         }
                         else if (R_X86_64_64 == r_type) {
-                            user_init_va = get_te64(&dynsym[ELF64_R_SYM(r_info)].st_value);
+                            unsigned const symj = ELF64_R_SYM(r_info);
+                            if (symnum_max <= symj) {
+                                throwCantPack("bad symbol %#x in DT_INIT_ARRAY[0] relocation", symj);
+                            }
+                            user_init_va = get_te64(&dynsym[symj].st_value);
                         }
                         else {
                             char msg[50]; snprintf(msg, sizeof(msg),


### PR DESCRIPTION
1. canPack_Shdr inspects the relocation that targets DT_INIT_ARRAY[0] while scanning a shared object to pack, and for an absolute relocation (R_ARM_ABS32 / R_386_32 / R_AARCH64_ABS64 / R_RISCV_64 / R_X86_64_64) it takes the symbol index from the file's r_info via ELF32_R_SYM / ELF64_R_SYM.
2. dynsym is the raw (Elf_Sym*)elf_find_dynamic(DT_SYMTAB) pointer into file_image, so reading dynsym[symj].st_value with an unbounded symj from a crafted relocation indexes well past file_image (the raw pointer is not covered by the MemBuffer/xspan checks).
3. get_dynsym_name already bounds the same dynsym access with symnum_max; applied the same check at the five DT_INIT_ARRAY relocation sites (32-bit ARM/i386 and 64-bit AArch64/RISC-V/x86_64) before the read, throwing CantPack on an out-of-range index.