### PR TITLE
validate LC_SEGMENT nsects against cmdsize in macho canPack

### DIFF
--- a/src/p_mach.cpp
+++ b/src/p_mach.cpp
@@ -2034,6 +2034,18 @@ tribool PackMachBase<T>::canPack()
         headway -= cmdsize;
         if (lc_seg == cmd) {
             msegcmd[j] = *segptr;
+            // is_bad_linker_command() only checks that cmdsize encodes a whole
+            // number of sections; the nsects field itself is never compared
+            // against cmdsize. pack4dylib() later walks segptr->nsects section
+            // commands from (1+ segptr), so an inflated nsects reads past the
+            // end of rawmseg. Require the two to agree.
+            unsigned const segcmdsize = lc_seg_info[sizeof(Addr) >> 3].segcmdsize;
+            unsigned const seccmdsize = lc_seg_info[sizeof(Addr) >> 3].seccmdsize;
+            if (segptr->nsects != (cmdsize - segcmdsize) / seccmdsize) {
+                char buf[64]; snprintf(buf, sizeof(buf),
+                    "bad LC_SEGMENT[%u].nsects %#x", j, (unsigned) segptr->nsects);
+                throwCantPack(buf);
+            }
             if (!strcmp("__TEXT", segptr->segname)) {
                 Mach_section_command const *secp =
                     (Mach_section_command const *)(const void*)(const char*)(1+ segptr);


### PR DESCRIPTION
1. canPack checks each LC_SEGMENT only through is_bad_linker_command, which confirms cmdsize encodes a whole number of sections but never checks the segment's nsects field against cmdsize.
2. rawmseg holds exactly mhdri.sizeofcmds bytes, and pack4dylib later walks segcmdtmp.nsects section commands from (1+ seg), so a dylib whose final segment carries a cmdsize for zero sections but an inflated nsects makes the section reads run past rawmseg and copies the over-read bytes into the packed output.
3. Reject a segment whose nsects disagrees with (cmdsize - segcmdsize)/seccmdsize next to the other load-command checks, before pack4dylib reads the sections.