### PR TITLE
bound bss_nfo struct read in ps1 findBssSection

### DIFF
--- a/src/p_ps1.cpp
+++ b/src/p_ps1.cpp
@@ -361,7 +361,7 @@ bool PackPs1::findBssSection() {
     byte reg;
     const LE32 *const p1 = ACC_CCAST(const LE32 *, ibuf + (ih.epc - ih.tx_ptr));
 
-    if ((ih.epc - ih.tx_ptr + (BSS_CHK_LIMIT * 4)) > fdata_size)
+    if ((ih.epc - ih.tx_ptr + (BSS_CHK_LIMIT * 4) + sizeof(bss_nfo)) > fdata_size)
         return false;
 
     // check 18 opcodes for sw zero,0(x)


### PR DESCRIPTION
1. findBssSection scans the entry-point code of a PS-X EXE for the bss setup. It forms a raw `const LE32 *p1 = ibuf + (ih.epc - ih.tx_ptr)` into the input body, where ibuf holds fdata_size = file_size - 2048 bytes, and guards only `(ih.epc - ih.tx_ptr) + BSS_CHK_LIMIT*4 <= fdata_size`, i.e. it reserves 72 bytes past the entry offset.
2. The scan then reads p1[BSS_CHK_LIMIT] in the outer loop (offset +72) and casts &p1[i] to a 16-byte bss_nfo for i up to BSS_CHK_LIMIT (offset up to +88). Both are raw pointers not covered by the MemBuffer bounds checks, so a crafted file whose epc/tx_ptr make `epc - tx_ptr + 72 == fdata_size` passes the guard and over-reads up to 16 bytes past ibuf (ASan heap-buffer-overflow on the p1[18] / bss_nfo read). This runs on the default console pack path.
3. Added sizeof(bss_nfo) to the window check so the struct read at the last scanned index stays inside ibuf; legitimate inputs keep epc - tx_ptr small and are unaffected.
