### PR TITLE
bound DT_RELSZ relocation walk in calls_crt1

### DIFF
--- a/src/p_lx_elf.cpp
+++ b/src/p_lx_elf.cpp
@@ -2749,7 +2749,11 @@ bool PackLinuxElf64::calls_crt1(Elf64_Rela const *rela, int sz)
     if (!dynsym || !dynstr || !rela) {
         return false;
     }
+    char const *const file_end = (char const *)&file_image[0] + file_size_u;
     for (unsigned relnum= 0; 0 < sz; (sz -= sizeof(Elf64_Rela)), ++rela, ++relnum) {
+        if (file_end < (char const *)(1+ rela)) {
+            break;  // DT_RELASZ/DT_PLTRELSZ runs past EOF
+        }
         unsigned const symnum = get_te64(&rela->r_info) >> 32;
         char const *const symnam = get_dynsym_name(symnum, relnum);
         if (0==strcmp(symnam, "__libc_start_main")  // glibc
@@ -2785,7 +2789,11 @@ bool PackLinuxElf32::calls_crt1(Elf32_Rel const *rel, int sz)
     if (!dynsym || !dynstr || !rel) {
         return false;
     }
+    char const *const file_end = (char const *)&file_image[0] + file_size_u;
     for (unsigned relnum= 0; 0 < sz; (sz -= sizeof(Elf32_Rel)), ++rel, ++relnum) {
+        if (file_end < (char const *)(1+ rel)) {
+            break;  // DT_RELSZ/DT_PLTRELSZ runs past EOF
+        }
         unsigned const symnum = get_te32(&rel->r_info) >> 8;
         char const *const symnam = get_dynsym_name(symnum, relnum);
         if (0==strcmp(symnam, "__libc_start_main")  // glibc


### PR DESCRIPTION
calls_crt1 (both the 32-bit and 64-bit overloads) scans the dynamic relocation table during canPack to decide whether an ET_DYN file is a PIE main program (it looks for __libc_start_main and friends).

1. the table start from elf_find_dynamic(DT_REL/DT_RELA) is bounded to within the file, but the byte length comes straight from DT_RELSZ / DT_RELASZ (and DT_PLTRELSZ) and is never checked against the file.
2. the loop then walks the raw Elf_Rel/Elf_Rela pointer for that many bytes and reads rel->r_info each step, so once it passes the end of file_image it reads out of bounds. sort_DT_offsets validates the DT_REL/DT_RELA *address* but not the matching size tag, so nothing else catches it.

Bound each record against the end of file_image before reading and stop the scan when the declared size runs past EOF.

Reproduced with a crafted x86_64 ET_DYN whose DT_RELASZ is far larger than the file; an ASan build reports a heap-buffer-overflow read at the rel->r_info load in calls_crt1, and the same input is rejected cleanly after the change.