### PR TITLE
bound object numbers before iobject_table index in wcle pack

### DIFF
--- a/src/p_wcle.cpp
+++ b/src/p_wcle.cpp
@@ -129,7 +129,7 @@ tribool PackWcle::canPack() {
 
 void PackWcle::encodeEntryTable() {
     unsigned count, object, n;
-    byte *p = ientries;
+    SPAN_S_VAR(byte, p, ientries, soentries);
     n = 0;
     while (*p) {
         count = *p;
@@ -138,7 +138,10 @@ void PackWcle::encodeEntryTable() {
             p += 2;
         else if (p[1] == 3) // 32-bit bundle
         {
-            object = get_le16(p + 2) - 1;
+            object = get_le16(p + 2);
+            if (object == 0 || object > objects)
+                throwCantPack("bad object number in entry table");
+            object -= 1;
             set_le16(p + 2, 1);
             p += 4;
             for (; count; count--, p += 5)
@@ -429,6 +432,8 @@ void PackWcle::pack(OutputFile *fo) {
 
     if (ih.init_ss_object != objects)
         throwCantPack("the stack is not in the last object");
+    if (ih.init_cs_object == 0 || ih.init_cs_object > objects)
+        throwCantPack("bad init_cs_object");
 
     preprocessFixups();
 


### PR DESCRIPTION
PackWcle::pack indexes iobject_table (sized to `objects` entries) with ih.init_cs_object taken straight from the LE header, without the bound it already applies to init_ss_object two lines above, so a crafted watcom/le input with init_cs_object outside [1, objects] reads past the small heap array at the IOT() dereference (ASan reports a heap-buffer-overflow read at p_wcle.cpp:435 on a minimal crafted file). encodeEntryTable has the same problem for a 32-bit entry-table bundle, where the object number from the file indexes iobject_table and the table is walked through a raw pointer, while the decode twin decodeEntryTable already validates the object and uses a bounds-checked span. The fix bounds both object numbers to [1, objects] before the dereference and gives encodeEntryTable the same SPAN_S walk as decodeEntryTable.