### PR TITLE
bound gnu_hash chain against DT_SYMTAB in elf_lookup

### DIFF
--- a/src/p_lx_elf.cpp
+++ b/src/p_lx_elf.cpp
@@ -8920,6 +8920,10 @@ Elf32_Sym const *PackLinuxElf32::elf_lookup(char const *name) const
                             throwCantPack("bad DT_GNU_HASH[%#x]  head=%u",
                                 (unsigned)(hp - hasharr), hhead);
                         }
+                        if (symnum_max <= (unsigned)(dsp - dynsym)) {
+                            throwCantPack("bad gnu_hash chain past DT_SYMTAB[%#x]",
+                                symnum_max);
+                        }
                         k = get_te32(hp);
                         if (0==((h ^ k)>>1)) {
                             unsigned const st_name = get_te32(&dsp->st_name);
@@ -9031,6 +9035,10 @@ Elf64_Sym const *PackLinuxElf64::elf_lookup(char const *name) const
                         if (gashend <= hp) {
                             throwCantPack("bad gnu_hash[%#tx]  head=%u",
                                 hp - hasharr, hhead);
+                        }
+                        if (symnum_max <= (unsigned)(dsp - dynsym)) {
+                            throwCantPack("bad gnu_hash chain past DT_SYMTAB[%#x]",
+                                symnum_max);
                         }
                         k = get_te32(hp);
                         if (0==((h ^ k)>>1)) {


### PR DESCRIPTION
1. elf_lookup() resolves a name (JNI_OnLoad on the pack path) through the DT_GNU_HASH chain, stepping dsp across DT_SYMTAB and hp across the 4-byte hash array together.
2. Only hp is bounded each iteration (against gashend); dsp is checked once at entry via `symnum_max <= hhead` and never again. An ElfXX_Sym is wider than a hash slot, so a crafted DT_GNU_HASH whose chain has no terminator advances dsp past the end of DT_SYMTAB while hp is still in range, and `get_te32(&dsp->st_name)` then reads out of bounds.
3. Added the `symnum_max` bound on dsp inside the 32-bit and 64-bit loops, matching the `l_sym <= &dynsym[si]` guard the DT_HASH path a few lines above already applies.

Verified with a crafted x86_64 ET_DYN: before, the walk reads a symbol past DT_SYMTAB; after, it stops with `bad gnu_hash chain past DT_SYMTAB`.
