### PR TITLE
bound len before ibuf write in 32-bit un_shlib_1

### DIFF
--- a/src/p_lx_elf.cpp
+++ b/src/p_lx_elf.cpp
@@ -7377,6 +7377,8 @@ void PackLinuxElf32::un_shlib_1(
             if (sz_block1 == sz_elf_hdrs) { // new style
                 unsigned const len = (yct_off ? yct_off : xct_off) - sz_elf_hdrs;
                 unsigned const ipos = fi->tell();
+                if ((upx_uint64_t)sz_elf_hdrs + len > ibuf.getSize())
+                    throwCantUnpack("bad xct_off or yct_off");
                 fi->seek(sz_elf_hdrs, SEEK_SET);
                 fi->readx(&ibuf[sz_elf_hdrs], len);
                 if (is_asl) {


### PR DESCRIPTION
1. the new-style branch computes `len = (yct_off ? yct_off : xct_off) - sz_elf_hdrs`, where xct_off derives from overlay_offset and yct_off from a spliced Shdr sh_offset, both taken from the packed file.
2. `fi->readx(&ibuf[sz_elf_hdrs], len)` then writes len bytes; `&ibuf[sz_elf_hdrs]` only bounds-checks the small index, and ibuf is sized `blocksize + OVERHEAD`, so a large len writes past the allocation during `upx -d`.

Added the `sz_elf_hdrs + len > ibuf.getSize()` check that `PackLinuxElf64::un_shlib_1` already performs, before the read. The 64-bit twin has this guard; the 32-bit path was missing it.